### PR TITLE
fixed: image paths for maven testing blog

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -14,6 +14,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+*.orig
 
 npm-debug.log*
 yarn-debug.log*

--- a/website/blog/2022-11-11-maven-testing-in-harness/maven-testing-in-harness.md
+++ b/website/blog/2022-11-11-maven-testing-in-harness/maven-testing-in-harness.md
@@ -23,12 +23,12 @@ Now let’s move to the next part of the pipeline, which is to select the infras
 #### Step-3:
 Moving on to the execution step, let’s add a **Run Step** and name it as “testrun” and under the container registry add the already created Docker Connector, and under the image add the “rvancea/maven-chrome-jdk8”. Now let’s add a shell command to run `mvn clean compile -DsuiteXmlFile=Batch1 test`  and apply the changes. 
 
-![testrun](website/blog/2022-11-11-maven-testing-in-harness/testrun.png)
+![testrun](./testrun.png)
 
 #### Step-4:
 Now, let’s add another **Run Step** similar to the above and name it as reports, just here contrary to the above step the command changes to `find . -name "*.xml"`.
 
-![filesgen](website/blog/2022-11-11-maven-testing-in-harness/filesgen.png)
+![filesgen](./filesgen.png)
 
 #### Step-5:
 It’s time to add the failure strategy now as a **Run Step**, with the following command.
@@ -44,14 +44,14 @@ else
  exit 0
 fi
 ```
-![faliurestrat](website/blog/2022-11-11-maven-testing-in-harness/failurestrat.png)
+![faliurestrat](./failurestrat.png)
 
 #### Step-6:
 Now, since the pipeline is complete, let’s save and run the same and the results looks like the following on the console logs.
 
-![result](website/blog/2022-11-11-maven-testing-in-harness/result.png)
+![result](./result.png)
 
-![reports](website/blog/2022-11-11-maven-testing-in-harness/reports.png)
+![reports](./reports.png)
 
 Once the run is successful, the above list of files are generated and can be further stored and processed as the test reports. 
 


### PR DESCRIPTION
Image paths for the Maven testing blogs were broken. 
- directed to path access from current folder 